### PR TITLE
Code button

### DIFF
--- a/_posts/2013-10-15-adi-interview.md
+++ b/_posts/2013-10-15-adi-interview.md
@@ -2,6 +2,7 @@
 layout: post
 title: ADI Interview Workshop
 category: event
+code: adicu/interview_help
 event_date: Tuesday, October 15
 event_time: 6:00 - 8:00 PM
 event_location: CS Lounge

--- a/blog/index.html
+++ b/blog/index.html
@@ -12,11 +12,14 @@ title: Blog
         <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
         <h3><a href="{{ post.url }}">{{ post.date | date_to_string }}</a></h3>
       </div>
-    
+
     <div class="social">
       <a target="_blank" href="https://twitter.com/intent/tweet?text={{ post.title }}&url=http://adicu.com{{ post.url }}&via=adicu"><button class="ss-btn ss-btn-tweet">Tweet</button></a>
       <a target="_blank" href="http://www.facebook.com/sharer/sharer.php?u=http://adicu.com{{ post.url }}"><button class="ss-btn ss-btn-facebook">Share</button></a>
       <a target="_blank" href="https://plus.google.com/share?url=http://adicu.com{{ post.url }}"><button class="ss-btn ss-btn-google">Google+</button></a>
+      {% if post.code %}
+        <a target="_blank" href="https://github.com/{{ post.code }}"><button class='ss-btn ss-btn-github'>Github</button></a>
+			{% endif %}
     </div>
 
     <div class="text-content">


### PR DESCRIPTION
Adds a github button if `code` is defined in the post template. Expects a string in the form `<username>/<repo name>`.

It set it in the interview post to confirm it worked:
![screenshot 2013-11-09 11 45 37](https://f.cloud.github.com/assets/2801090/1507013/63cfd330-495e-11e3-803f-b02210c5fa72.png)
