### PR TITLE
make /blog titles link to their posts

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -8,7 +8,7 @@ title: Blog
 {% for post in paginator.posts %}
 <article class="post">
 
-  <h2 class="title">{{ post.title }}</h2>
+  <a href="{{ post.url }}"><h2 class="title">{{ post.title }}</h2></a>
   <h2 class="date">{{ post.date | date_to_string }}</h2>
 
   <div class="social">


### PR DESCRIPTION
Because the "Read more" buttons look so much like the sharing buttons it doesn't stand out. I think most users are used to clicking on the title to see the full post
- has not visual change so I didn't attach screenshots
